### PR TITLE
Fix jsonxx abort issue

### DIFF
--- a/src/EternalModLoader.cpp
+++ b/src/EternalModLoader.cpp
@@ -450,7 +450,7 @@ int main(int argc, char **argv)
     if (!PackageMapSpecInfo::ModifyPackageMapSpec(ProgramOptions::BasePath, streamDBContainerList)) {
         std::cout << Colors::Red << "ERROR: " << Colors::Reset << "Failed to write " << PackageMapSpecInfo::PackageMapSpecPath << std::endl;
     }
-    else {
+    else if (PackageMapSpecInfo::WasPackageMapSpecModified) {
         std::cout << "Modified "<< Colors::Yellow << PackageMapSpecInfo::PackageMapSpecPath << Colors::Reset << '\n';
     }
 

--- a/src/ReplaceChunks.cpp
+++ b/src/ReplaceChunks.cpp
@@ -640,17 +640,17 @@ void ReplaceChunks(MemoryMappedFile& memoryMappedFile, ResourceContainer& resour
 
             // Read the blang JSON and add the strings to the .blang file
             jsonxx::Object blangJson;
+            jsonxx::Array blangJsonStrings;
 
             try {
                 std::string blangJsonString(reinterpret_cast<char*>(modFile.FileBytes.data()), modFile.FileBytes.size());
                 blangJson.parse(blangJsonString);
+                blangJsonStrings = blangJson.get<jsonxx::Array>("strings");
             }
             catch (...) {
                 os << Colors::Red << "ERROR: " << Colors::Reset << "Failed to parse EternalMod/strings/" << fs::path(modFile.Name).replace_extension(".json").string() << '\n';
                 continue;
             }
-
-            jsonxx::Array blangJsonStrings = blangJson.get<jsonxx::Array>("strings");
 
             for (size_t i = 0; i < blangJsonStrings.size(); i++) {
                 jsonxx::Object blangJsonString = blangJsonStrings.get<jsonxx::Object>(i);

--- a/vendor/jsonxx/jsonxx.cc
+++ b/vendor/jsonxx/jsonxx.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
 #include <vector>
 #include <limits>
 #include <mutex>
@@ -26,8 +27,7 @@
 #include <cassert>
 void jsonxx::assertion( const char *file, int line, const char *expression, bool result ) {
     if( !result ) {
-        fprintf( stderr, "[JSONXX] expression '%s' failed at %s:%d -> ", expression, file, line );
-        assert( 0 );
+        throw std::runtime_error("Failed to parse JSON");
     }
 }
 #if defined(JSONXX_REENABLE_NDEBUG)


### PR DESCRIPTION
This commit fixes a jsonxx behaviour that would cause the program to abort in case of malformed JSON blang files. Fixes #7.